### PR TITLE
fix: change to async_forward_entry_setup

### DIFF
--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -65,7 +65,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         COORDINATOR: coordinator,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    for platform in PLATFORMS:
+        hass.async_add_job(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
     return True
 
 


### PR DESCRIPTION
async_setup_platforms is being deprecated in Home Assistant so switching to async_forward_entry_setups before 2023.3.0 is released.