### PR TITLE
update to initial_state: true

### DIFF
--- a/packages/nws_alerts_package.yaml
+++ b/packages/nws_alerts_package.yaml
@@ -51,7 +51,7 @@ variable:
 
 automation:
   - alias: 'NWS Check for Multi Alerts'
-    initial_state: 'on'
+    initial_state: true
     trigger:
       - platform: state
         entity_id: sensor.nws_alerts
@@ -76,7 +76,7 @@ automation:
                 entity_id: input_boolean.nws_multi_alert
   
   - alias: 'NWS Weather Alert Pop Up Control'
-    initial_state: 'on'
+    initial_state: true
     trigger:
       - platform: state
         entity_id: sensor.nws_alerts
@@ -142,7 +142,7 @@ automation:
               "{{ state_attr('sensor.nws_alerts', 'display_desc').split('\n\n-\n\n')[0] }}"
           
   - alias: NWS Notification Weather Alert
-    initial_state: 'on'
+    initial_state: true
     trigger:
       platform: state
       entity_id: sensor.nws_alerts
@@ -157,7 +157,7 @@ automation:
             "NWS: {{ state_attr('sensor.nws_alerts', 'title').split(' - ')[0] }}"
             
   - alias: NWS Announce Weather Alert
-    initial_state: 'on'
+    initial_state: true
     trigger:
       - platform: state
         entity_id: sensor.nws_alerts
@@ -231,7 +231,7 @@ automation:
             {% endif %}
                   
   - alias: NWS Announce Weather Alert for MBR
-    initial_state: 'on'
+    initial_state: true
     trigger:
       - platform: state
         entity_id: sensor.nws_alerts
@@ -283,7 +283,7 @@ automation:
           message: "Attention!,,,Attention!,,,The National Weather Service Has issued a Tornado Warning for our area."
               
   - alias: NWS Update Event ID Variable
-    initial_state: 'on'
+    initial_state: true
     trigger:
       - platform: state
         entity_id: sensor.nws_alerts


### PR DESCRIPTION
initial_state: true is the correct syntax now.

initial_state: 'on' is deprecated 
https://www.home-assistant.io/docs/automation/yaml/#automation-initial-state