### PR TITLE
Add "Onset" Attribute on Alerts

### DIFF
--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -192,6 +192,7 @@ async def async_get_state(config, coords) -> dict:
         "message_type": None,
         "event_status": None,
         "event_severity": None,
+        "event_onset": None,
         "event_expires": None,
         "display_desc": None,
         "spoken_desc": None,
@@ -240,6 +241,7 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
         "message_type": None,
         "event_status": None,
         "event_severity": None,
+        "event_onset": None,
         "event_expires": None,
         "display_desc": None,
         "spoken_desc": None,
@@ -268,6 +270,7 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
         message_type = ""
         event_status = ""
         event_severity = ""
+        event_onset = ""
         event_expires = ""
         display_desc = ""
         spoken_desc = ""
@@ -286,6 +289,7 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
             instruction = alert["properties"]["instruction"]
             severity = alert["properties"]["severity"]
             certainty = alert["properties"]["certainty"]
+            onset = alert["properties"]["onset"]
             expires = alert["properties"]["expires"]
 
             # if event in events:
@@ -298,13 +302,14 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
                 display_desc += "\n\n-\n\n"
 
             display_desc += (
-                "\n>\nHeadline: %s\nStatus: %s\nMessage Type: %s\nSeverity: %s\nCertainty: %s\nExpires: %s\nDescription: %s\nInstruction: %s"
+                "\n>\nHeadline: %s\nStatus: %s\nMessage Type: %s\nSeverity: %s\nCertainty: %s\nOnset: %s\nExpires: %s\nDescription: %s\nInstruction: %s"
                 % (
                     headline,
                     status,
                     type,
                     severity,
                     certainty,
+                    onset,
                     expires,
                     description,
                     instruction,
@@ -330,6 +335,11 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
                 event_severity += " - "
 
             event_severity += severity
+
+            if event_onset != "":
+                event_onset += " - "
+            
+            event_onset += onset
 
             if event_expires != "":
                 event_expires += " - "
@@ -362,6 +372,7 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
             values["message_type"] = message_type
             values["event_status"] = event_status
             values["event_severity"] = event_severity
+            values["event_onset"] = event_onset
             values["event_expires"] = event_expires
             values["display_desc"] = display_desc
             values["spoken_desc"] = spoken_desc

--- a/custom_components/nws_alerts/sensor.py
+++ b/custom_components/nws_alerts/sensor.py
@@ -146,6 +146,7 @@ class NWSAlertSensor(CoordinatorEntity):
         attrs["message_type"] = self.coordinator.data["message_type"]
         attrs["event_status"] = self.coordinator.data["event_status"]
         attrs["event_severity"] = self.coordinator.data["event_severity"]
+        attrs["event_onset"] = self.coordinator.data["event_onset"]
         attrs["event_expires"] = self.coordinator.data["event_expires"]
         attrs["display_desc"] = self.coordinator.data["display_desc"]
         attrs["spoken_desc"] = self.coordinator.data["spoken_desc"]


### PR DESCRIPTION
I thought Issue #67 by @kidhasmoxy was a good idea... Sometimes alerts are issued but don't take effect for many hours, even days. This PR adds the "onset" attribute from the data source.