### PR TITLE
fix-prevent-frequent-state-change-on-api-glitch

### DIFF
--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -157,6 +157,9 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         async with timeout(self.timeout):
             try:
                 data = await update_alerts(self.config, coords)
+            except AttributeError:
+                _LOGGER.debug("Error fetching most recent data from NWS Alerts API; will continue trying")
+                data = "AttributeError"
             except Exception as error:
                 raise UpdateFailed(error) from error
             return data

--- a/custom_components/nws_alerts/sensor.py
+++ b/custom_components/nws_alerts/sensor.py
@@ -5,7 +5,10 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import (
+    callback,
+    HomeAssistant, 
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -166,3 +169,10 @@ class NWSAlertSensor(CoordinatorEntity):
             manufacturer="NWS",
             name="NWS Alerts",
         )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if self.coordinator.data != "AttributeError":
+            self.async_write_ha_state()
+


### PR DESCRIPTION
Fix for Issue #70.

Addresses momentary inability of the NWS Alerts API to respond with valid data, which is a frequent occurrence. When this happens, the entity from the integration becomes unavailable, which can cause unnecessary and annoying alert notifications in some HA installations.

The suggested fix is to NOT update the entity's state when this error occurs. All other behavior remains unchanged, including the reporting of all other types of errors.

If the API remains in this failed state for an extended period of time, the data in the entity can become stale. However, I believe it is better to present the latest available alert data, rather than no data at all.

As to the type of log message reported, this is such a frequent issue with no action necessary on the part of the user that after some reflection, I decided to log it as type `debug`.