### PR TITLE
Add a service that will reply a list of active alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-
 *.pyc
 .coverage
+.venv
+.vscode

--- a/custom_components/nws_alerts/config_flow.py
+++ b/custom_components/nws_alerts/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for NWS Alerts."""
+
 from __future__ import annotations
 
 import logging
@@ -10,7 +11,9 @@ from homeassistant import config_entries
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.data_entry_flow import FlowResult
+
 
 from .const import (
     API_ENDPOINT,
@@ -35,50 +38,68 @@ MENU_OPTIONS = ["zone", "gps"]
 MENU_GPS = ["gps_loc", "gps_tracker"]
 
 
-def _get_schema_zone(hass: Any, user_input: list, default_dict: list) -> Any:
+def _get_schema_zone(
+    hass: Any, user_input: dict[str, Any] | None, default_dict: dict[str, Any]
+) -> Any:
     """Gets a schema using the default_dict as a backup."""
     if user_input is None:
         user_input = {}
 
-    def _get_default(key):
+    def _get_default(key: str) -> Any:
         """Gets default value for key."""
         return user_input.get(key, default_dict.get(key))
 
     return vol.Schema(
         {
-            vol.Required(CONF_ZONE_ID, default=_get_default(CONF_ZONE_ID)): str,
+            vol.Required(
+                CONF_ZONE_ID, default=_get_default(CONF_ZONE_ID)
+            ): str,
             vol.Optional(CONF_NAME, default=_get_default(CONF_NAME)): str,
-            vol.Optional(CONF_INTERVAL, default=_get_default(CONF_INTERVAL)): int,
-            vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT)): int,
+            vol.Optional(
+                CONF_INTERVAL, default=_get_default(CONF_INTERVAL)
+            ): int,
+            vol.Optional(
+                CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT)
+            ): int,
         }
     )
 
 
-def _get_schema_gps(hass: Any, user_input: list, default_dict: list) -> Any:
+def _get_schema_gps(
+    hass: Any, user_input: dict[str, Any] | None, default_dict: dict[str, Any]
+) -> Any:
     """Gets a schema using the default_dict as a backup."""
     if user_input is None:
         user_input = {}
 
-    def _get_default(key):
+    def _get_default(key: str) -> Any:
         """Gets default value for key."""
         return user_input.get(key, default_dict.get(key))
 
     return vol.Schema(
         {
-            vol.Required(CONF_GPS_LOC, default=_get_default(CONF_GPS_LOC)): str,
+            vol.Required(
+                CONF_GPS_LOC, default=_get_default(CONF_GPS_LOC)
+            ): str,
             vol.Optional(CONF_NAME, default=_get_default(CONF_NAME)): str,
-            vol.Optional(CONF_INTERVAL, default=_get_default(CONF_INTERVAL)): int,
-            vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT)): int,
+            vol.Optional(
+                CONF_INTERVAL, default=_get_default(CONF_INTERVAL)
+            ): int,
+            vol.Optional(
+                CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT)
+            ): int,
         }
     )
 
 
-def _get_schema_tracker(hass: Any, user_input: list, default_dict: list) -> Any:
+def _get_schema_tracker(
+    hass: Any, user_input: dict[str, Any] | None, default_dict: dict[str, Any]
+) -> Any:
     """Gets a schema using the default_dict as a backup."""
     if user_input is None:
         user_input = {}
 
-    def _get_default(key: str, fallback_default: Any = None) -> None:
+    def _get_default(key: str, fallback_default: Any = None) -> Any:
         """Gets default value for key."""
         return user_input.get(key, default_dict.get(key, fallback_default))
 
@@ -88,8 +109,12 @@ def _get_schema_tracker(hass: Any, user_input: list, default_dict: list) -> Any:
                 CONF_TRACKER, default=_get_default(CONF_TRACKER, "(none)")
             ): vol.In(_get_entities(hass, TRACKER_DOMAIN)),
             vol.Optional(CONF_NAME, default=_get_default(CONF_NAME)): str,
-            vol.Optional(CONF_INTERVAL, default=_get_default(CONF_INTERVAL)): int,
-            vol.Optional(CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT)): int,
+            vol.Optional(
+                CONF_INTERVAL, default=_get_default(CONF_INTERVAL)
+            ): int,
+            vol.Optional(
+                CONF_TIMEOUT, default=_get_default(CONF_TIMEOUT)
+            ): int,
         }
     )
 
@@ -97,15 +122,17 @@ def _get_schema_tracker(hass: Any, user_input: list, default_dict: list) -> Any:
 def _get_entities(
     hass: HomeAssistant,
     domain: str,
-    search: List[str] = None,
-    extra_entities: List[str] = None,
+    search: List[str] | None = None,
+    extra_entities: List[str] | None = None,
 ) -> List[str]:
     data = ["(none)"]
     if domain not in hass.data:
         return data
 
     for entity in hass.data[domain].entities:
-        if search is not None and not any(map(entity.entity_id.__contains__, search)):
+        if search is not None and not any(
+            map(entity.entity_id.__contains__, search)
+        ):
             continue
         data.append(entity.entity_id)
 
@@ -115,7 +142,7 @@ def _get_entities(
     return data
 
 
-async def _get_zone_list(self) -> list | None:
+async def _get_zone_list(self) -> str | None:
     """Return list of zone by lat/lon"""
 
     data = None
@@ -124,24 +151,25 @@ async def _get_zone_list(self) -> list | None:
 
     headers = {"User-Agent": USER_AGENT, "Accept": "application/geo+json"}
 
-    url = API_ENDPOINT + "/zones?point=%s,%s" % (lat, lon)
+    url = f"{API_ENDPOINT}/zones?point={lat},{lon}"
 
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers=headers) as r:
-            _LOGGER.debug("getting zone list for %s,%s from %s" % (lat, lon, url))
+            _LOGGER.debug("getting zone list for %s,%s from %s", lat, lon, url)
             if r.status == 200:
                 data = await r.json()
 
-    zone_list = []
+    zone_list: List[str] = []
     if data is not None:
         if "features" in data:
             x = 0
             while len(data[JSON_FEATURES]) > x:
-                zone_list.append(data[JSON_FEATURES][x][JSON_PROPERTIES][JSON_ID])
+                zone_list.append(
+                    str(data[JSON_FEATURES][x][JSON_PROPERTIES][JSON_ID])
+                )
                 x += 1
             _LOGGER.debug("Zones list: %s", zone_list)
-            zone_list = ",".join(str(x) for x in zone_list)  # convert list to str
-            return zone_list
+            return ",".join(zone_list)
     return None
 
 
@@ -156,19 +184,12 @@ class NWSAlertsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._data = {}
         self._errors = {}
-
-    # async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
-    #     """Import a config entry."""
-
-    #     user_input = user_input[DOMAIN]
-    #     result: FlowResult = await self.async_step_user(user_input=user_input)
-    #     if errors := result.get("errors"):
-    #         return self.async_abort(reason=next(iter(errors.values())))
-    #     return result
+        self._zone_list = None
+        self._gps_loc = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the flow initialized by the user."""
         return self.async_show_menu(step_id="user", menu_options=MENU_OPTIONS)
 
@@ -178,15 +199,21 @@ class NWSAlertsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the flow initialized by the user."""
         return self.async_show_menu(step_id="gps", menu_options=MENU_GPS)
 
-    async def async_step_gps_tracker(self, user_input={}):
+    async def async_step_gps_tracker(
+        self, user_input: dict[str, Any] | None = None
+    ):
         """Handle a flow for device trackers."""
         self._errors = {}
         if user_input is not None:
             self._data.update(user_input)
-            return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
+            return self.async_create_entry(
+                title=self._data[CONF_NAME], data=self._data
+            )
         return await self._show_config_gps_tracker(user_input)
 
-    async def _show_config_gps_tracker(self, user_input):
+    async def _show_config_gps_tracker(
+        self, user_input: dict[str, Any] | None
+    ):
         """Show the configuration form to edit location data."""
 
         # Defaults
@@ -202,7 +229,7 @@ class NWSAlertsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_gps_loc(self, user_input={}):
+    async def async_step_gps_loc(self, user_input: dict[str, Any] | None):
         """Handle a flow initialized by the user."""
         lat = self.hass.config.latitude
         lon = self.hass.config.longitude
@@ -211,10 +238,12 @@ class NWSAlertsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             self._data.update(user_input)
-            return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
+            return self.async_create_entry(
+                title=self._data[CONF_NAME], data=self._data
+            )
         return await self._show_config_gps_loc(user_input)
 
-    async def _show_config_gps_loc(self, user_input):
+    async def _show_config_gps_loc(self, user_input: dict[str, Any] | None):
         """Show the configuration form to edit location data."""
 
         # Defaults
@@ -231,17 +260,19 @@ class NWSAlertsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_zone(self, user_input={}):
+    async def async_step_zone(self, user_input: dict[str, Any] | None):
         """Handle a flow initialized by the user."""
         self._errors = {}
         self._zone_list = await _get_zone_list(self)
 
         if user_input is not None:
             self._data.update(user_input)
-            return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
+            return self.async_create_entry(
+                title=self._data[CONF_NAME], data=self._data
+            )
         return await self._show_config_zone(user_input)
 
-    async def _show_config_zone(self, user_input):
+    async def _show_config_zone(self, user_input: dict[str, Any] | None):
         """Show the configuration form to edit location data."""
 
         # Defaults
@@ -273,14 +304,16 @@ class NWSAlertsOptionsFlow(config_entries.OptionsFlow):
         self._data = dict(config_entry.data)
         self._errors = {}
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
         """Manage Mail and Packages options."""
         if user_input is not None:
             self._data.update(user_input)
             return self.async_create_entry(title="", data=self._data)
         return await self._show_options_form(user_input)
 
-    async def async_step_gps_loc(self, user_input={}):
+    async def async_step_gps_loc(
+        self, user_input: dict[str, Any] | None = None
+    ):
         """Handle a flow initialized by the user."""
         self._errors = {}
 
@@ -289,7 +322,9 @@ class NWSAlertsOptionsFlow(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=self._data)
         return await self._show_options_form(user_input)
 
-    async def async_step_gps_tracker(self, user_input={}):
+    async def async_step_gps_tracker(
+        self, user_input: dict[str, Any] | None = None
+    ):
         """Handle a flow initialized by the user."""
         self._errors = {}
 
@@ -298,7 +333,7 @@ class NWSAlertsOptionsFlow(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=self._data)
         return await self._show_options_form(user_input)
 
-    async def async_step_zone(self, user_input={}):
+    async def async_step_zone(self, user_input: dict[str, Any] | None = None):
         """Handle a flow initialized by the user."""
         self._errors = {}
 
@@ -307,7 +342,7 @@ class NWSAlertsOptionsFlow(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=self._data)
         return await self._show_options_form(user_input)
 
-    async def _show_options_form(self, user_input):
+    async def _show_options_form(self, user_input: dict[str, Any] | None):
         """Show the configuration form to edit location data."""
 
         if CONF_GPS_LOC in self.config.data:
@@ -316,15 +351,19 @@ class NWSAlertsOptionsFlow(config_entries.OptionsFlow):
                 data_schema=_get_schema_gps(self.hass, user_input, self._data),
                 errors=self._errors,
             )
-        elif CONF_ZONE_ID in self.config.data:
+        if CONF_ZONE_ID in self.config.data:
             return self.async_show_form(
                 step_id="zone",
-                data_schema=_get_schema_zone(self.hass, user_input, self._data),
+                data_schema=_get_schema_zone(
+                    self.hass, user_input, self._data
+                ),
                 errors=self._errors,
             )
-        elif CONF_TRACKER in self.config.data:
+        if CONF_TRACKER in self.config.data:
             return self.async_show_form(
                 step_id="gps_tracker",
-                data_schema=_get_schema_tracker(self.hass, user_input, self._data),
+                data_schema=_get_schema_tracker(
+                    self.hass, user_input, self._data
+                ),
                 errors=self._errors,
             )

--- a/custom_components/nws_alerts/const.py
+++ b/custom_components/nws_alerts/const.py
@@ -24,3 +24,5 @@ PLATFORM = "sensor"
 ATTRIBUTION = "Data provided by Weather.gov"
 COORDINATOR = "coordinator"
 PLATFORMS = ["sensor"]
+
+LIST_ALERTS_SERVICE_NAME = "list"

--- a/custom_components/nws_alerts/sensor.py
+++ b/custom_components/nws_alerts/sensor.py
@@ -1,9 +1,8 @@
 import logging
-import uuid
 
 import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -49,7 +48,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass, config, async_add_entities, discovery_info=None
+):
     """Configuration from yaml"""
     if DOMAIN not in hass.data.keys():
         hass.data.setdefault(DOMAIN, {})
@@ -58,9 +59,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         elif CONF_GPS_LOC in config:
             config.entry_id = slugify(f"{config.get(CONF_GPS_LOC)}")
         elif CONF_TRACKER in config:
-            config.entry_id = slugify(f"{config.get(CONF_TRACKER)}")            
+            config.entry_id = slugify(f"{config.get(CONF_TRACKER)}")
         else:
-            raise ValueError("GPS, Zone or Device Tracker needs to be configured.")
+            raise ValueError(
+                "GPS, Zone or Device Tracker needs to be configured."
+            )
         config.data = config
     else:
         if CONF_ZONE_ID in config:
@@ -70,7 +73,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         elif CONF_TRACKER in config:
             config.entry_id = slugify(f"{config.get(CONF_TRACKER)}")
         else:
-            raise ValueError("GPS, Zone or Device Tracker needs to be configured.")
+            raise ValueError(
+                "GPS, Zone or Device Tracker needs to be configured."
+            )
         config.data = config
 
     # Setup the data coordinator
@@ -128,7 +133,7 @@ class NWSAlertSensor(CoordinatorEntity):
         """Return the state of the sensor."""
         if self.coordinator.data is None:
             return None
-        elif "state" in self.coordinator.data.keys():
+        if "state" in self.coordinator.data.keys():
             return self.coordinator.data["state"]
         return None
 

--- a/custom_components/nws_alerts/sensor.py
+++ b/custom_components/nws_alerts/sensor.py
@@ -56,8 +56,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-LIST_ALERTS_SCHEMA = vol.Schema({})
-
 
 async def async_setup_platform(
     hass, config, async_add_entities, discovery_info=None
@@ -116,7 +114,7 @@ async def async_setup_entry(
     platform = async_get_current_platform()
     platform.async_register_entity_service(
         LIST_ALERTS_SERVICE_NAME,
-        LIST_ALERTS_SCHEMA,
+        cv.BASE_ENTITY_SCHEMA,
         "async_get_alerts",
         None,
         SupportsResponse.ONLY,

--- a/custom_components/nws_alerts/services.yaml
+++ b/custom_components/nws_alerts/services.yaml
@@ -1,0 +1,4 @@
+list:
+  target:
+    entity:
+      integration: nws_alerts

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,6 @@
 black
 isort
-pytest
-pytest-cov
-pytest-homeassistant-custom-component
+pytest==8.1.1
+pytest-cov==5.0.0
+pytest-homeassistant-custom-component==0.13.116
+pytest-mock==3.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+asyncio_mode = auto

--- a/tests/const.py
+++ b/tests/const.py
@@ -4,3 +4,147 @@ CONFIG_DATA = {"name": "NWS Alerts", "zone_id": "AZZ540,AZC013"}
 CONFIG_DATA_2 = {"name": "NWS Alerts YAML", "zone_id": "AZZ540"}
 CONFIG_DATA_3 = {"name": "NWS Alerts", "gps_loc": "123,-456"}
 CONFIG_DATA_BAD = {"name": "NWS Alerts"}
+
+NWS_COUNT_RESPONSE = {"zones": {"AZZ540": 2, "AZC013": 0}}
+
+NWS_RESPONSE = {
+    "@context": [
+        "https://geojson.org/geojson-ld/geojson-context.jsonld",
+        {
+            "@version": "1.1",
+            "wx": "https://api.weather.gov/ontology#",
+            "@vocab": "https://api.weather.gov/ontology#",
+        },
+    ],
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "id": "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.f8c2bb518263d1d5123b3248bf95d57331ebf147.001.1",
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-97.73, 30.89],
+                        [-97.62, 30.87],
+                        [-97.31, 30.75],
+                        [-97.39, 30.63],
+                        [-97.51, 30.5],
+                        [-97.69000000000001, 30.34],
+                        [-97.87000000000002, 30.35],
+                        [-98.00000000000001, 30.42],
+                        [-97.93000000000002, 30.610000000000003],
+                        [-97.73, 30.89],
+                    ]
+                ],
+            },
+            "properties": {
+                "@id": "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.f8c2bb518263d1d5123b3248bf95d57331ebf147.001.1",
+                "@type": "wx:Alert",
+                "id": "urn:oid:2.49.0.1.840.0.f8c2bb518263d1d5123b3248bf95d57331ebf147.001.1",
+                "areaDesc": "Travis, TX; Williamson, TX",
+                "geocode": {
+                    "SAME": ["048453", "048491"],
+                    "UGC": ["TXC453", "TXC491"],
+                },
+                "affectedZones": [
+                    "https://api.weather.gov/zones/county/TXC453",
+                    "https://api.weather.gov/zones/county/TXC491",
+                ],
+                "references": [],
+                "sent": "2024-04-28T14:00:00-05:00",
+                "effective": "2024-04-28T14:00:00-05:00",
+                "onset": "2024-04-28T14:00:00-05:00",
+                "expires": "2024-04-28T17:00:00-05:00",
+                "ends": "2024-04-28T17:00:00-05:00",
+                "status": "Actual",
+                "messageType": "Alert",
+                "category": "Met",
+                "severity": "Minor",
+                "certainty": "Likely",
+                "urgency": "Expected",
+                "event": "Flood Advisory",
+                "sender": "w-nws.webmaster@noaa.gov",
+                "senderName": "NWS Austin/San Antonio TX",
+                "headline": "Flood Advisory issued April 28 at 2:00PM CDT until April 28 at 5:00PM CDT by NWS Austin/San Antonio TX",
+                "description": "* WHAT...Urban and small stream flooding caused by excessive\nrainfall is expected.",
+                "instruction": "Turn around, don't drown when encountering flooded roads. Most flood\ndeaths occur in vehicles.",
+                "response": "Avoid",
+                "parameters": {
+                    "AWIPSidentifier": ["FLSEWX"],
+                    "WMOidentifier": ["WGUS84 KEWX 281900"],
+                    "NWSheadline": [
+                        "FLOOD ADVISORY IN EFFECT UNTIL 5 PM CDT THIS AFTERNOON"
+                    ],
+                    "BLOCKCHANNEL": ["EAS", "NWEM", "CMAS"],
+                    "VTEC": [
+                        "/O.NEW.KEWX.FA.Y.0036.240428T1900Z-240428T2200Z/"
+                    ],
+                    "eventEndingTime": ["2024-04-28T22:00:00+00:00"],
+                },
+            },
+        },
+        {
+            "id": "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.84378ece4d14118d62d5eb0387b031aef7e5f77d.001.1",
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-97.62, 30.87],
+                        [-97.27000000000001, 30.740000000000002],
+                        [-97.70000000000002, 30.55],
+                        [-97.91000000000001, 30.63],
+                        [-97.70000000000002, 30.89],
+                        [-97.62, 30.87],
+                    ]
+                ],
+            },
+            "properties": {
+                "@id": "https://api.weather.gov/alerts/urn:oid:2.49.0.1.840.0.84378ece4d14118d62d5eb0387b031aef7e5f77d.001.1",
+                "@type": "wx:Alert",
+                "id": "urn:oid:2.49.0.1.840.0.84378ece4d14118d62d5eb0387b031aef7e5f77d.001.1",
+                "areaDesc": "Williamson",
+                "geocode": {"SAME": ["048491"], "UGC": ["TXZ173"]},
+                "affectedZones": [
+                    "https://api.weather.gov/zones/forecast/TXZ173"
+                ],
+                "references": [],
+                "sent": "2024-04-28T13:31:00-05:00",
+                "effective": "2024-04-28T13:31:00-05:00",
+                "onset": "2024-04-28T13:31:00-05:00",
+                "expires": "2024-04-28T14:15:00-05:00",
+                "ends": None,
+                "status": "Actual",
+                "messageType": "Alert",
+                "category": "Met",
+                "severity": "Moderate",
+                "certainty": "Observed",
+                "urgency": "Expected",
+                "event": "Special Weather Statement",
+                "sender": "w-nws.webmaster@noaa.gov",
+                "senderName": "NWS Austin/San Antonio TX",
+                "headline": "Special Weather Statement issued April 28 at 1:31PM CDT by NWS Austin/San Antonio TX",
+                "description": "At 131 PM CDT, Doppler radar was tracking a strong thunderstorm near places.",
+                "instruction": "If outdoors, consider seeking shelter inside a building.",
+                "response": "Execute",
+                "parameters": {
+                    "AWIPSidentifier": ["SPSEWX"],
+                    "WMOidentifier": ["WWUS84 KEWX 281831"],
+                    "NWSheadline": [
+                        "A strong thunderstorm will impact portions of central Williamson County through 215 PM CDT"
+                    ],
+                    "eventMotionDescription": [
+                        "2024-04-28T18:31:00-00:00...storm...223DEG...20KT...30.66,-97.78"
+                    ],
+                    "maxWindGust": ["50 MPH"],
+                    "maxHailSize": ["0.75"],
+                    "BLOCKCHANNEL": ["EAS", "NWEM", "CMAS"],
+                    "EAS-ORG": ["WXR"],
+                },
+            },
+        },
+    ],
+    "title": "Current watches, warnings, and advisories for 30.836 N, 97.592 W",
+    "updated": "2024-04-28T19:00:49+00:00",
+}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,5 @@
 """Test for config flow"""
 
-from unittest.mock import patch
 import pytest
 from homeassistant import config_entries, setup
 from homeassistant.core import HomeAssistant

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,11 @@
 """Tests for init."""
-import pytest
-from unittest.mock import patch
 
-from homeassistant.const import CONF_NAME
+import pytest
+
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.helpers.entity_registry import async_get
-from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.nws_alerts.const import CONF_ZONE_ID, DOMAIN
+from custom_components.nws_alerts.const import DOMAIN
 from tests.const import CONFIG_DATA, CONFIG_DATA_3
 
 pytestmark = pytest.mark.asyncio
@@ -17,7 +14,7 @@ pytestmark = pytest.mark.asyncio
 async def test_setup_entry(
     hass,
 ):
-    """Test settting up entities."""
+    """Test setting up entities."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="NWS Alerts",
@@ -57,27 +54,3 @@ async def test_unload_entry(hass):
     assert await hass.config_entries.async_remove(entries[0].entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
-
-
-# async def test_import(hass):
-#     """Test importing a config."""
-#     entry = MockConfigEntry(
-#         domain=DOMAIN,
-#         title="NWS Alerts",
-#         data=CONFIG_DATA,
-#     )
-#     await async_setup_component(hass, "persistent_notification", {})
-#     with patch(
-#         "custom_components.nws_alerts.async_setup_entry",
-#         return_value=True,
-#     ) as mock_setup_entry:
-
-#         ent_reg = async_get(hass)
-#         ent_entry = ent_reg.async_get_or_create(
-#             "sensor", DOMAIN, unique_id="replaceable_unique_id", config_entry=entry
-#         )
-#         entity_id = ent_entry.entity_id
-#         entry.add_to_hass(hass)
-#         await hass.config_entries.async_setup(entry.entry_id)
-#         assert entry.unique_id is None
-#         assert ent_reg.async_get(entity_id).unique_id == entry.entry_id

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -82,6 +82,7 @@ async def test_sensor_service(hass: HomeAssistant, mocker):
         return_response=True,
     )
     assert response
+    assert response[NWS_SENSOR] is list[dict[str, Any]]
     alerts: list[dict[str, Any]] = response[NWS_SENSOR]
     assert len(alerts) == 2
     assert alerts[0]["title"] == "Flood Advisory"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,7 @@
 """Test NWS Alerts Sensors"""
 
+from typing import Any
+
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import (
@@ -9,7 +11,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.nws_alerts.const import DOMAIN, API_ENDPOINT
+from custom_components.nws_alerts.const import (
+    DOMAIN,
+    API_ENDPOINT,
+    LIST_ALERTS_SERVICE_NAME,
+)
 from tests.const import (
     CONFIG_DATA,
     CONFIG_DATA_2,
@@ -42,6 +48,75 @@ async def test_sensor(hass: HomeAssistant):
     entity = entity_registry.async_get(NWS_SENSOR_2)
     assert entity
     assert entity.unique_id == f"{slugify(entry.title)}_{entry.entry_id}"
+
+
+async def test_sensor_service(hass: HomeAssistant, mocker):
+    """Validate the service call to get alerts"""
+
+    session_builder = AiohttpClientMocker()
+    session_builder.request(
+        "get", f"{API_ENDPOINT}/alerts/active/count", json=NWS_COUNT_RESPONSE
+    )
+    session_builder.request(
+        "get",
+        f"{API_ENDPOINT}/alerts/active?zone={CONFIG_DATA['zone_id']}",
+        json=NWS_RESPONSE,
+    )
+
+    mocker.patch(
+        "aiohttp.ClientSession",
+        return_value=session_builder.create_session(None),
+    )
+
+    await setup_entry(hass, "NWS Alerts", CONFIG_DATA)
+
+    state = hass.states.get(NWS_SENSOR)
+    assert state
+    assert state.state == "2"
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        LIST_ALERTS_SERVICE_NAME,
+        target={"entity_id": NWS_SENSOR},
+        blocking=True,
+        return_response=True,
+    )
+    assert response
+    alerts: list[dict[str, Any]] = response[NWS_SENSOR]
+    assert len(alerts) == 2
+    assert alerts[0]["title"] == "Flood Advisory"
+    assert alerts[0]["message_type"] == "Alert"
+    assert alerts[0]["event_status"] == "Actual"
+    assert alerts[0]["event_severity"] == "Minor"
+    assert alerts[0]["event_expires"] == "2024-04-28T17:00:00-05:00"
+    assert alerts[0]["display_desc"] == (
+        "Headline: FLOOD ADVISORY IN EFFECT UNTIL 5 PM CDT THIS AFTERNOON"
+        "\nStatus: Actual\nMessage Type: Alert\nSeverity: Minor\n"
+        "Certainty: Likely\nExpires: 2024-04-28T17:00:00-05:00\nDescription: "
+        "* WHAT...Urban and small stream flooding caused by excessive\n"
+        "rainfall is expected.\nInstruction: Turn around, don't drown when "
+        "encountering flooded roads. Most flood\ndeaths occur in vehicles."
+    )
+    assert alerts[0]["spoken_desc"] == (
+        "FLOOD ADVISORY IN EFFECT UNTIL 5 PM CDT THIS AFTERNOON"
+    )
+    assert alerts[1]["title"] == "Special Weather Statement"
+    assert alerts[1]["message_type"] == "Alert"
+    assert alerts[1]["event_status"] == "Actual"
+    assert alerts[1]["event_severity"] == "Moderate"
+    assert alerts[1]["event_expires"] == "2024-04-28T14:15:00-05:00"
+    assert alerts[1]["display_desc"] == (
+        "Headline: A strong thunderstorm will impact portions of central "
+        "Williamson County through 215 PM CDT\nStatus: Actual\nMessage Type: "
+        "Alert\nSeverity: Moderate\nCertainty: Observed\nExpires: "
+        "2024-04-28T14:15:00-05:00\nDescription: At 131 PM CDT, Doppler radar "
+        "was tracking a strong thunderstorm near places.\nInstruction: If "
+        "outdoors, consider seeking shelter inside a building."
+    )
+    assert alerts[1]["spoken_desc"] == (
+        "A strong thunderstorm will impact portions of central Williamson "
+        "County through 215 PM CDT"
+    )
 
 
 async def test_sensor_attributes(hass: HomeAssistant, mocker):
@@ -99,9 +174,10 @@ async def test_sensor_attributes(hass: HomeAssistant, mocker):
         "A strong thunderstorm will impact portions of central Williamson "
         "County through 215 PM CDT"
     )
+    assert "alerts" not in state.attributes
 
 
-async def setup_entry(hass, entry_title, config):
+async def setup_entry(hass: HomeAssistant, entry_title, config):
     """Set up the sensor in hass"""
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,21 @@
 """Test NWS Alerts Sensors"""
+
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.test_util.aiohttp import (
+    AiohttpClientMocker,
+)
+from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 from homeassistant.helpers import entity_registry as er
 
-from custom_components.nws_alerts.const import DOMAIN
-from tests.const import CONFIG_DATA, CONFIG_DATA_2, CONFIG_DATA_BAD
+from custom_components.nws_alerts.const import DOMAIN, API_ENDPOINT
+from tests.const import (
+    CONFIG_DATA,
+    CONFIG_DATA_2,
+    NWS_RESPONSE,
+    NWS_COUNT_RESPONSE,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -13,28 +23,90 @@ NWS_SENSOR = "sensor.nws_alerts"
 NWS_SENSOR_2 = "sensor.nws_alerts_yaml"
 
 
-async def test_sensor(hass):
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="NWS Alerts",
-        data=CONFIG_DATA,
-    )
+async def test_sensor(hass: HomeAssistant):
+    """Test the sensor."""
+    entry = await setup_entry(hass, "NWS Alerts", CONFIG_DATA)
 
-    entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert "nws_alerts" in hass.config.components
     state = hass.states.get(NWS_SENSOR)
     assert state
     entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(NWS_SENSOR)
+    assert entity
     assert entity.unique_id == f"{slugify(entry.title)}_{entry.entry_id}"
 
+    entry = await setup_entry(hass, "NWS Alerts YAML", CONFIG_DATA_2)
+
+    state = hass.states.get(NWS_SENSOR_2)
+    assert state
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get(NWS_SENSOR_2)
+    assert entity
+    assert entity.unique_id == f"{slugify(entry.title)}_{entry.entry_id}"
+
+
+async def test_sensor_attributes(hass: HomeAssistant, mocker):
+    """Validate the format of the sensor attributes"""
+
+    session_builder = AiohttpClientMocker()
+    session_builder.request(
+        "get", f"{API_ENDPOINT}/alerts/active/count", json=NWS_COUNT_RESPONSE
+    )
+    session_builder.request(
+        "get",
+        f"{API_ENDPOINT}/alerts/active?zone={CONFIG_DATA['zone_id']}",
+        json=NWS_RESPONSE,
+    )
+
+    mocker.patch(
+        "aiohttp.ClientSession",
+        return_value=session_builder.create_session(None),
+    )
+
+    await setup_entry(hass, "NWS Alerts", CONFIG_DATA)
+
+    state = hass.states.get(NWS_SENSOR)
+    assert state
+    assert state.state == "2"
+    assert (
+        state.attributes["title"]
+        == "Flood Advisory - Special Weather Statement"
+    )
+    assert state.attributes["message_type"] == "Alert - Alert"
+    assert state.attributes["event_status"] == "Actual - Actual"
+    assert state.attributes["event_severity"] == "Minor - Moderate"
+    assert (
+        state.attributes["event_expires"]
+        == "2024-04-28T17:00:00-05:00 - 2024-04-28T14:15:00-05:00"
+    )
+    assert state.attributes["display_desc"] == (
+        "\n>\nHeadline: FLOOD ADVISORY IN EFFECT UNTIL 5 PM CDT THIS AFTERNOON"
+        "\nStatus: Actual\nMessage Type: Alert\nSeverity: Minor\n"
+        "Certainty: Likely\nExpires: 2024-04-28T17:00:00-05:00\nDescription: "
+        "* WHAT...Urban and small stream flooding caused by excessive\n"
+        "rainfall is expected.\nInstruction: Turn around, don't drown when "
+        "encountering flooded roads. Most flood\ndeaths occur in vehicles."
+        "\n\n-\n\n"
+        "\n>\nHeadline: A strong thunderstorm will impact portions of central "
+        "Williamson County through 215 PM CDT\nStatus: Actual\nMessage Type: "
+        "Alert\nSeverity: Moderate\nCertainty: Observed\nExpires: "
+        "2024-04-28T14:15:00-05:00\nDescription: At 131 PM CDT, Doppler radar "
+        "was tracking a strong thunderstorm near places.\nInstruction: If "
+        "outdoors, consider seeking shelter inside a building."
+    )
+    assert state.attributes["spoken_desc"] == (
+        "FLOOD ADVISORY IN EFFECT UNTIL 5 PM CDT THIS AFTERNOON"
+        "\n\n-\n\n"
+        "A strong thunderstorm will impact portions of central Williamson "
+        "County through 215 PM CDT"
+    )
+
+
+async def setup_entry(hass, entry_title, config):
+    """Set up the sensor in hass"""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        title="NWS Alerts YAML",
-        data=CONFIG_DATA_2,
+        title=entry_title,
+        data=config,
     )
 
     entry.add_to_hass(hass)
@@ -42,8 +114,4 @@ async def test_sensor(hass):
     await hass.async_block_till_done()
 
     assert "nws_alerts" in hass.config.components
-    state = hass.states.get(NWS_SENSOR_2)
-    assert state
-    entity_registry = er.async_get(hass)
-    entity = entity_registry.async_get(NWS_SENSOR_2)
-    assert entity.unique_id == f"{slugify(entry.title)}_{entry.entry_id}"
+    return entry


### PR DESCRIPTION
I found the concatenated strings in the entity attributes a little cumbersome to write automatons for.  And I saw the recommendation in [Issue 66](https://github.com/finity69x2/nws_alerts/issues/66) to take advantage of the new service response feature.

This adds the new service `nws_alerts.list` which can be called on any entry provided by this integration.  

ps.
When starting on this change, my pylint/flake8/mypy had a lot of warnings that I cleaned up first.  I'll gladly remove those from this PR if they are making the change harder to follow.

I also noticed some of the typehints were wrong, so I updated those as well.