### PR TITLE
Change to async_forward_entry_setups

### DIFF
--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -1,10 +1,10 @@
 """ NWS Alerts """
+
 import logging
 from datetime import timedelta
 
 import aiohttp
 from async_timeout import timeout
-from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -79,10 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         COORDINATOR: coordinator,
     }
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 

--- a/custom_components/nws_alerts/const.py
+++ b/custom_components/nws_alerts/const.py
@@ -1,3 +1,5 @@
+from homeassistant.const import Platform
+
 # API
 API_ENDPOINT = "https://api.weather.gov"
 USER_AGENT = "Home Assistant"
@@ -23,4 +25,4 @@ DOMAIN = "nws_alerts"
 PLATFORM = "sensor"
 ATTRIBUTION = "Data provided by Weather.gov"
 COORDINATOR = "coordinator"
-PLATFORMS = ["sensor"]
+PLATFORMS = [Platform.SENSOR]


### PR DESCRIPTION
Changes to use `async_forward_entry_setups` instead

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

Fixes #82 