### PR TITLE
Extract additional properties from alerts

### DIFF
--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -282,6 +282,10 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
             else:
                 tmp_dict["Headline"] = event
 
+            # Valid Time Event Coding (https://www.weather.gov/bmx/vtec)
+            if "VTEC" in alert["properties"]["parameters"]:
+                tmp_dict["VTEC"] = alert["properties"]["parameters"]["VTEC"][0]
+
             tmp_dict["Type"] = alert["properties"]["messageType"]
             tmp_dict["Status"] = alert["properties"]["status"]
             tmp_dict["Severity"] = alert["properties"]["severity"]
@@ -293,6 +297,11 @@ async def async_get_alerts(zone_id: str = "", gps_loc: str = "") -> dict:
             tmp_dict["AreasAffected"] = alert["properties"]["areaDesc"]
             tmp_dict["Description"] = alert["properties"]["description"]
             tmp_dict["Instruction"] = alert["properties"]["instruction"]
+
+            # eventCode.SAME and eventCode.NationalWeatherService are always included
+            # code list: https://vlab.noaa.gov/web/nws-common-alerting-protocol/cap-documentation#_eventcode_inclusion-16
+            tmp_dict["SAMEEventCode"] = alert["properties"]["eventCode"]["SAME"][0]
+            tmp_dict["NWSEventCode"] = alert["properties"]["eventCode"]["NationalWeatherService"][0]
 
             alert_list.append(tmp_dict)
 


### PR DESCRIPTION
Store VTEC, SAMEEventCode, and NWSEventCode. This provides more information to enhance and simplify automations.

---

For example, to handle the initial issuance of a Tornado Warning, instead of using `'Tornado Warning' in Event` (or `'tornado warning' in (Event | lower)` if you are paranoid about case-sensitive string comparisons like I am) and checking `Type == 'Alert'` to exclude updates, the SAMEEventCode field can be used:

`SAMEEventCode == 'TOR'`

---

The [VTEC](https://www.weather.gov/bmx/vtec) field provides even more information when parsed which can also be useful for automations, especially the action group.