### PR TITLE
test: look up alerts sensor entity id dynamically

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,13 +4,11 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.nws_alerts.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.helpers import entity_registry as er
 from tests.const import CONFIG_DATA
 
 pytestmark = pytest.mark.asyncio
-
-NWS_SENSOR = "sensor.nws_alerts_alerts"
-NWS_SENSOR_2 = "sensor.nws_alerts_yaml"
 
 
 async def test_sensor(hass, mock_api):
@@ -26,7 +24,12 @@ async def test_sensor(hass, mock_api):
     await hass.async_block_till_done()
 
     assert "nws_alerts" in hass.config.components
-    state = hass.states.get(NWS_SENSOR)
+
+    # Entity id is derived from the configured name, so look it up dynamically
+    # rather than hard-coding a fragile sensor.nws_alerts_alerts literal.
+    entity_ids = hass.states.async_entity_ids(SENSOR_DOMAIN)
+    alerts_entity_id = next(eid for eid in entity_ids if eid.endswith("_alerts"))
+    state = hass.states.get(alerts_entity_id)
     assert state
     assert state.state == "2"
     assert state.attributes["Alerts"] == [
@@ -69,4 +72,4 @@ async def test_sensor(hass, mock_api):
     ]
     assert state.attributes["Alerts"][0]["ID"] == "7681487b-41c6-0308-1a00-3cade72982c1"
     entity_registry = er.async_get(hass)
-    assert entity_registry.async_get(NWS_SENSOR)
+    assert entity_registry.async_get(alerts_entity_id)


### PR DESCRIPTION
## Context

~The configured-name change made the hard-coded `sensor.nws_alerts_alerts` string literal unreliable in pytest.~

**EDIT:** tests/test_sensor.py has asserted sensor.nws_alerts since https://github.com/finity69x2/nws_alerts/commit/a234bff85b0f8845f1b902780b6b8c30fe2287d1 (Aug 2024), and that slug has never matched a fresh install of this integration.

The proposed changes discover the entity via the sensor domain instead so the test survives future entity_id format changes.

## Notes

- no-op change for working test setups
- fixes my own issues running tests against arbitrarily named entities
- statically configured test entity id -> now a dynamic entity lookup
- tests are now slightly more reliable for a wider range of entity ids, but still equally fragile to entity name scheme changes