### PR TITLE
feat: expose NWS geocode (UGC/SAME) on alert attributes

### DIFF
--- a/custom_components/nws_alerts/coordinator.py
+++ b/custom_components/nws_alerts/coordinator.py
@@ -170,7 +170,6 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
                     geocode = alert["properties"].get("geocode") or {}
                     tmp_dict["Geocode"] = {
                         "UGC": geocode.get("UGC", []),
-                        "SAME": geocode.get("SAME", []),
                     }
                     tmp_dict["Description"] = alert["properties"]["description"]
                     tmp_dict["Instruction"] = alert["properties"]["instruction"]

--- a/custom_components/nws_alerts/coordinator.py
+++ b/custom_components/nws_alerts/coordinator.py
@@ -167,6 +167,11 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
                     tmp_dict["Expires"] = alert["properties"]["expires"]
                     tmp_dict["Ends"] = alert["properties"]["ends"]
                     tmp_dict["AreasAffected"] = alert["properties"]["areaDesc"]
+                    geocode = alert["properties"].get("geocode") or {}
+                    tmp_dict["Geocode"] = {
+                        "UGC": geocode.get("UGC", []),
+                        "SAME": geocode.get("SAME", []),
+                    }
                     tmp_dict["Description"] = alert["properties"]["description"]
                     tmp_dict["Instruction"] = alert["properties"]["instruction"]
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -62,7 +62,6 @@ async def test_sensor(hass, mock_api):
                     "AZZ550",
                     "AZZ551",
                 ],
-                "SAME": ["004013"],
             },
         },
         {
@@ -82,7 +81,7 @@ async def test_sensor(hass, mock_api):
             "Expires": "2024-07-19T21:00:00-07:00",
             "Description": "AQAPSR\n\nThe Arizona Department of Environmental Quality (ADEQ) has issued an\nOzone High Pollution Advisory for the Phoenix Metro Area through\nFriday.\n\nThis means that forecast weather conditions combined with existing\nozone levels are expected to result in local maximum 8-hour ozone\nconcentrations that pose a health risk. Adverse health effects\nincrease as air quality deteriorates.\n\nOzone is an air contaminant which can cause breathing difficulties\nfor children, older adults, as well as persons with respiratory\nproblems. A decrease in physical activity is recommended.\n\nYou are urged to car pool, telecommute or use mass transit.\nThe use of gasoline-powered equipment should be reduced or done late\nin the day.\n\nFor details on this High Pollution Advisory, visit the ADEQ internet\nsite at www.azdeq.gov/forecast/phoenix or call 602-771-2300.",
             "Instruction": None,
-            "Geocode": {"UGC": ["AZC013"], "SAME": ["004013"]},
+            "Geocode": {"UGC": ["AZC013"]},
         },
     ]
     assert state.attributes["Alerts"][0]["ID"] == "7681487b-41c6-0308-1a00-3cade72982c1"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -50,6 +50,20 @@ async def test_sensor(hass, mock_api):
             "Expires": "2024-07-19T03:00:00-07:00",
             "Description": "* WHAT...Dangerously hot conditions. Afternoon temperatures 112 to\n116 expected. Major Heat Risk. Overexposure can cause heat cramps\nand heat exhaustion to develop and, without intervention, can lead\nto heat stroke.\n\n* WHERE...The Northwest Valley of the Phoenix Metro Area, The East\nValley of the Phoenix Metro Area, Buckeye/Avondale, Deer Valley,\nCentral Phoenix, North Phoenix/Glendale, Scottsdale/Paradise\nValley, South Mountain/Ahwatukee, and Southeast Valley/Queen Creek.\n\n* WHEN...From 10 AM Friday to 8 PM MST Saturday.\n\n* IMPACTS...Heat related illnesses increase significantly during\nextreme heat events.\n\n* ADDITIONAL DETAILS...In Maricopa County, call 2-1-1 to find a free\ncooling center, transportation, water, and more.\nhttps://www.maricopa.gov/heat",
             "Instruction": "An Excessive Heat Warning means that a period of very hot\ntemperatures, even by local standards, will occur. Actions should be\ntaken to lessen the impact of the extreme heat.\n\nTake extra precautions if you work or spend time outside. When\npossible, reschedule strenuous activities to early morning or\nevening. Know the signs and symptoms of heat exhaustion and heat\nstroke. Wear lightweight and loose-fitting clothing when possible\nand drink plenty of water.\n\nTo reduce risk during outdoor work, the Occupational Safety and\nHealth Administration recommends scheduling frequent rest breaks in\nshaded or air conditioned environments. Anyone overcome by heat\nshould be moved to a cool and shaded location. Heat stroke is an\nemergency! Call 9 1 1.\n\nPublic cooling shelters are available in some areas. Consult county\nofficials for more details.",
+            "Geocode": {
+                "UGC": [
+                    "AZZ537",
+                    "AZZ540",
+                    "AZZ542",
+                    "AZZ543",
+                    "AZZ544",
+                    "AZZ546",
+                    "AZZ548",
+                    "AZZ550",
+                    "AZZ551",
+                ],
+                "SAME": ["004013"],
+            },
         },
         {
             "AreasAffected": "Maricopa, AZ",
@@ -68,6 +82,7 @@ async def test_sensor(hass, mock_api):
             "Expires": "2024-07-19T21:00:00-07:00",
             "Description": "AQAPSR\n\nThe Arizona Department of Environmental Quality (ADEQ) has issued an\nOzone High Pollution Advisory for the Phoenix Metro Area through\nFriday.\n\nThis means that forecast weather conditions combined with existing\nozone levels are expected to result in local maximum 8-hour ozone\nconcentrations that pose a health risk. Adverse health effects\nincrease as air quality deteriorates.\n\nOzone is an air contaminant which can cause breathing difficulties\nfor children, older adults, as well as persons with respiratory\nproblems. A decrease in physical activity is recommended.\n\nYou are urged to car pool, telecommute or use mass transit.\nThe use of gasoline-powered equipment should be reduced or done late\nin the day.\n\nFor details on this High Pollution Advisory, visit the ADEQ internet\nsite at www.azdeq.gov/forecast/phoenix or call 602-771-2300.",
             "Instruction": None,
+            "Geocode": {"UGC": ["AZC013"], "SAME": ["004013"]},
         },
     ]
     assert state.attributes["Alerts"][0]["ID"] == "7681487b-41c6-0308-1a00-3cade72982c1"


### PR DESCRIPTION
## Changes

Adds a Geocode dict to each alert containing the UGC code list from the NWS properties.geocode object.

## Motivation

This enables zone sorting/filtering in frontend components.

## Why Draft?

HA Entity Attribute limit is 16KB, this would count towards that and potentially break existing setups hitting that limit (like #95)

Keeping this one as a Draft until mitigation approach is defined.