### PR TITLE
Feat/user agent

### DIFF
--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -5,7 +5,9 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry, async_get
+from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 
 from .const import (
     CONF_GPS_LOC,
@@ -54,10 +56,17 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     config_entry.add_update_listener(update_listener)
 
+    # Build per-installation User-Agent per NWS API guidelines
+    instance_id = await async_get_instance_id(hass)
+    user_agent = f"nws_alerts homeassistant {instance_id}"
+    _LOGGER.debug("NWS User-Agent: %s", user_agent)
+
     # Setup the data coordinator
     coordinator = AlertsDataUpdateCoordinator(
         hass,
         config_entry,
+        session=async_get_clientsession(hass),
+        user_agent=user_agent,
     )
 
     # Wait for device tracker to become available on startup

--- a/custom_components/nws_alerts/__init__.py
+++ b/custom_components/nws_alerts/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     DOMAIN,
     ISSUE_URL,
     PLATFORMS,
+    USER_AGENT,
     VERSION,
 )
 from .coordinator import AlertsDataUpdateCoordinator
@@ -58,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     # Build per-installation User-Agent per NWS API guidelines
     instance_id = await async_get_instance_id(hass)
-    user_agent = f"nws_alerts homeassistant {instance_id}"
+    user_agent = USER_AGENT.format(instance_id)
     _LOGGER.debug("NWS User-Agent: %s", user_agent)
 
     # Setup the data coordinator

--- a/custom_components/nws_alerts/config_flow.py
+++ b/custom_components/nws_alerts/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -13,6 +12,8 @@ from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 
 from .const import (
     API_ENDPOINT,
@@ -26,9 +27,8 @@ from .const import (
     DEFAULT_NAME,
     DEFAULT_TIMEOUT,
     DOMAIN,
-    USER_AGENT,
-    LOOKUP_URL,
     ID_URL,
+    LOOKUP_URL,
 )
 
 JSON_FEATURES = "features"
@@ -127,11 +127,14 @@ async def _get_zone_list(self) -> str | None:
     lat = self.hass.config.latitude
     lon = self.hass.config.longitude
 
-    headers = {"User-Agent": USER_AGENT, "Accept": "application/geo+json"}
+    instance_id = await async_get_instance_id(self.hass)
+    user_agent = f"nws_alerts homeassistant {instance_id}"
+    headers = {"User-Agent": user_agent, "Accept": "application/geo+json"}
 
     url = f"{API_ENDPOINT}/zones?point={lat},{lon}"
 
-    async with aiohttp.ClientSession() as session, session.get(url, headers=headers) as r:
+    session = async_get_clientsession(self.hass)
+    async with session.get(url, headers=headers) as r:
         _LOGGER.debug("getting zone list for %s,%s from %s", lat, lon, url)
         if r.status == 200:
             data = await r.json()

--- a/custom_components/nws_alerts/config_flow.py
+++ b/custom_components/nws_alerts/config_flow.py
@@ -29,6 +29,7 @@ from .const import (
     DOMAIN,
     ID_URL,
     LOOKUP_URL,
+    USER_AGENT,
 )
 
 JSON_FEATURES = "features"
@@ -128,7 +129,7 @@ async def _get_zone_list(self) -> str | None:
     lon = self.hass.config.longitude
 
     instance_id = await async_get_instance_id(self.hass)
-    user_agent = f"nws_alerts homeassistant {instance_id}"
+    user_agent = USER_AGENT.format(instance_id)
     headers = {"User-Agent": user_agent, "Accept": "application/geo+json"}
 
     url = f"{API_ENDPOINT}/zones?point={lat},{lon}"

--- a/custom_components/nws_alerts/const.py
+++ b/custom_components/nws_alerts/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import Platform
 
 # API
 API_ENDPOINT = "https://api.weather.gov"
+USER_AGENT = "nws_alerts homeassistant {}"
 
 # Config
 CONF_TIMEOUT = "timeout"

--- a/custom_components/nws_alerts/const.py
+++ b/custom_components/nws_alerts/const.py
@@ -4,7 +4,6 @@ from homeassistant.const import Platform
 
 # API
 API_ENDPOINT = "https://api.weather.gov"
-USER_AGENT = "Home Assistant"
 
 # Config
 CONF_TIMEOUT = "timeout"

--- a/custom_components/nws_alerts/coordinator.py
+++ b/custom_components/nws_alerts/coordinator.py
@@ -19,7 +19,6 @@ from .const import (
     CONF_TIMEOUT,
     CONF_TRACKER,
     CONF_ZONE_ID,
-    USER_AGENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,12 +27,21 @@ _LOGGER = logging.getLogger(__name__)
 class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching NWS Alert data."""
 
-    def __init__(self, hass, config):
+    def __init__(
+        self,
+        hass,
+        config,
+        *,
+        session: aiohttp.ClientSession,
+        user_agent: str,
+    ):
         """Initialize."""
         self.interval = timedelta(minutes=config.data.get(CONF_INTERVAL))
         self.name = config.data.get(CONF_NAME)
         self.timeout = config.data.get(CONF_TIMEOUT)
         self._config = config
+        self._session = session
+        self._user_agent = user_agent
         self.hass = hass
 
         _LOGGER.debug("Data will be update every %s", self.interval)
@@ -117,7 +125,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             "alerts": [],
             "last_updated": datetime.now().isoformat(),
         }
-        headers = {"User-Agent": USER_AGENT, "Accept": "application/geo+json"}
+        headers = {"User-Agent": self._user_agent, "Accept": "application/geo+json"}
         data = None
 
         if zone_id != "":
@@ -127,7 +135,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             url = f"{API_ENDPOINT}/alerts/active?point={gps_loc}"
             _LOGGER.debug("getting alert for %s from %s", gps_loc, url)
 
-        async with aiohttp.ClientSession() as session, session.get(url, headers=headers) as r:
+        async with self._session.get(url, headers=headers) as r:
             if r.status == 200:
                 data = await r.json()
             else:


### PR DESCRIPTION
## Summary

- Build a unique User-Agent string per installation: `nws_alerts homeassistant <instance-id>`
- Replace ad-hoc `aiohttp.ClientSession()` creation with HA's managed session (`async_get_clientsession`) in both the coordinator and config flow
- Centralize the User-Agent format string in `const.py`

## Motivation

The [NWS API guidance](https://www.weather.gov/documentation/services-web-api) notes that automated security measures key on the User-Agent header. The current header is hardcoded to the same generic string for all installations, meaning one misbehaving install could get every install blocked. Including the integration name and HA instance ID makes each installation distinguishable to the NWS.

Switching to the HA managed session avoids creating and tearing down a new connection per request and reuses HA's shared connection pool and SSL context.

## Changes

- `const.py`: Replace the static `USER_AGENT` string with a format template that accepts the instance ID
- `__init__.py`: Resolve the instance ID via `async_get_instance_id`, build the User-Agent, and inject it along with the managed session into the coordinator
- `coordinator.py`: Accept `session` and `user_agent` as keyword-only constructor args instead of creating ad-hoc sessions
- `config_flow.py`: Build the same User-Agent for zone lookups during config flow, replace `aiohttp.ClientSession()` with `async_get_clientsession`